### PR TITLE
Follow Symlinks on Windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,6 +88,9 @@ module.exports = {
         : commonPlugins.concat([
             new webpack.HotModuleReplacementPlugin(),
         ]),
+    resolve: {
+        symlinks: false
+    },
     // Configuration for webpack-dev-server
     devServer: {
         publicPath: "/",


### PR DESCRIPTION
https://github.com/fable-compiler/Fable/issues/1490
As NuGet cache was moved to a secondard drive to obtain drive space on C:  webpack loader didn't follow the link. With the preopsed Change we no longer have the issue.