### PR TITLE
Use consistent type of quote for strings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,20 +6,20 @@
 
 // Dependencies. Also required: core-js, fable-loader, fable-compiler, @babel/core,
 // @babel/preset-env, babel-loader, sass, sass-loader, css-loader, style-loader, file-loader
-var path = require("path");
-var webpack = require("webpack");
+var path = require('path');
+var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
-var MiniCssExtractPlugin = require("mini-css-extract-plugin");
+var MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 var CONFIG = {
     // The tags to include the generated JS and CSS will be automatically injected in the HTML template
     // See https://github.com/jantimon/html-webpack-plugin
-    indexHtmlTemplate: "./src/index.html",
-    fsharpEntry: "./src/App.fsproj",
-    cssEntry: "./src/style.sass",
-    outputDir: "./deploy",
-    assetsDir: "./public",
+    indexHtmlTemplate: './src/index.html',
+    fsharpEntry: './src/App.fsproj',
+    cssEntry: './src/style.sass',
+    outputDir: './deploy',
+    assetsDir: './public',
     devServerPort: 8080,
     // When using webpack-dev-server, you may need to redirect some calls
     // to a external API server. See https://webpack.js.org/configuration/dev-server/#devserver-proxy
@@ -28,11 +28,11 @@ var CONFIG = {
     // More info at https://babeljs.io/docs/en/next/babel-preset-env.html
     babel: {
         presets: [
-            ["@babel/preset-env", {
+            ['@babel/preset-env', {
                 modules: false,
                 // This adds polyfills when needed. Requires core-js dependency.
                 // See https://babeljs.io/docs/en/babel-preset-env#usebuiltins
-                useBuiltIns: "usage",
+                useBuiltIns: 'usage',
                 corejs: 3
             }]
         ],
@@ -41,7 +41,7 @@ var CONFIG = {
 
 // If we're running the webpack-dev-server, assume we're in development mode
 var isProduction = !process.argv.find(v => v.indexOf('webpack-dev-server') !== -1);
-console.log("Bundling for " + (isProduction ? "production" : "development") + "...");
+console.log('Bundling for ' + (isProduction ? 'production' : 'development') + '...');
 
 // The HtmlWebpackPlugin allows us to use a template for the index.html page
 // and automatically injects <script> or <link> tags for generated bundles.
@@ -69,11 +69,11 @@ module.exports = {
         path: resolve(CONFIG.outputDir),
         filename: isProduction ? '[name].[hash].js' : '[name].js'
     },
-    mode: isProduction ? "production" : "development",
-    devtool: isProduction ? "source-map" : "eval-source-map",
+    mode: isProduction ? 'production' : 'development',
+    devtool: isProduction ? 'source-map' : 'eval-source-map',
     optimization: {
         splitChunks: {
-            chunks: "all"
+            chunks: 'all'
         },
     },
     // Besides the HtmlPlugin, we use the following plugins:
@@ -97,7 +97,7 @@ module.exports = {
     },
     // Configuration for webpack-dev-server
     devServer: {
-        publicPath: "/",
+        publicPath: '/',
         contentBase: resolve(CONFIG.assetsDir),
         port: CONFIG.devServerPort,
         proxy: CONFIG.devServerProxy,
@@ -113,7 +113,7 @@ module.exports = {
             {
                 test: /\.fs(x|proj)?$/,
                 use: {
-                    loader: "fable-loader",
+                    loader: 'fable-loader',
                     options: {
                         babel: CONFIG.babel
                     }
@@ -136,13 +136,13 @@ module.exports = {
                     'css-loader',
                     {
                       loader: 'sass-loader',
-                      options: { implementation: require("sass") }
+                      options: { implementation: require('sass') }
                     }
                 ],
             },
             {
                 test: /\.(png|jpg|jpeg|gif|svg|woff|woff2|ttf|eot)(\?.*)?$/,
-                use: ["file-loader"]
+                use: ['file-loader']
             }
         ]
     }


### PR DESCRIPTION
I really did not want to be the one to pick the type of quote and I suspect I'll be lynched whichever type I pick. The decision to use single quotes was made by following the first style guide I thought of consulting, which was JavaScript Standard Style. It may or may not have been subconsciously affected by my time as a Python developer.