### PR TITLE
Configure dev-server to listen on port 0.0.0.0

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,7 @@ module.exports = {
     devServer: {
         publicPath: '/',
         contentBase: resolve(CONFIG.assetsDir),
+        host: '0.0.0.0',
         port: CONFIG.devServerPort,
         proxy: CONFIG.devServerProxy,
         hot: true,


### PR DESCRIPTION
This allows accessing webpack dev server from outside of the box it's running.
Thanks to that change we can make https://github.com/SAFE-Stack/SAFE-template/pull/254 work.
Another scenario where it comes handy is when you want to attach to webpack dev server with external device, such as mobile phone or tablet.