### PR TITLE
Don't explicitely load HodModuleReloadPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,9 +83,7 @@ module.exports = {
                     from: resolve(CONFIG.assetsDir) }]
                 })
         ])
-        : commonPlugins.concat([
-            new webpack.HotModuleReplacementPlugin(),
-        ]),
+        : commonPlugins,
     resolve: {
         // See https://github.com/fable-compiler/Fable/issues/1490
         symlinks: false


### PR DESCRIPTION
Setting devServer option "hot" to true automatically loads HMR